### PR TITLE
Prevent crash on uploading a empty file

### DIFF
--- a/craedl/core.py
+++ b/craedl/core.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ class Auth():
     def __init__(self):
         if not os.path.isfile(os.path.expanduser(self.token_path)):
             raise errors.Missing_Token_Error
-    
+
     def __repr__(self):
         string = '{'
         for k, v in vars(self).items():
@@ -186,7 +186,7 @@ class Directory(Auth):
     def create_directory(self, name):
         """
         Create a new directory contained within this directory.
-        
+
         **Note:** This method returns the updated instance of this directory
         (because it has a new child). The recommended usage is:
 

--- a/craedl/core.py
+++ b/craedl/core.py
@@ -102,10 +102,15 @@ class Auth():
             an HTML error string if the response does not have status 200
         """
         token = open(os.path.expanduser(self.token_path)).readline().strip()
-        while True:
+
+        # Alternatively, return None or {}
+        empty = not data.peek()
+        if empty:
+           raise errors.File_Error(details=data.name)
+
+        while not empty:
             d = data.read(BUF_SIZE)
-            if not d:
-                break
+            empty = not data.peek()
             response = requests.put(
                 self.base_url + path,
                 data=d,

--- a/craedl/errors.py
+++ b/craedl/errors.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/craedl/errors.py
+++ b/craedl/errors.py
@@ -14,44 +14,37 @@
 
 import json
 
-class Connection_Refused_Error(Exception):
+class CraedlException(Exception):
+    """Base exception that all other exceptions should inherit from."""
     def __init__(self):
-        self.message = 'Failed to establish a connection to https://api.craedl.org.'
+        self.message = "Craedl Error."
 
     def __str__(self):
         return self.message
 
-class Invalid_Token_Error(Exception):
+class Connection_Refused_Error(CraedlException):
+    def __init__(self):
+        self.message = 'Failed to establish a connection to https://api.craedl.org.'
+
+class Invalid_Token_Error(CraedlException):
     def __init__(self):
         self.message = 'Your configured authentication token is invalid.\n'
         self.message += '  Use `python -m craedl` to configure your authentication token.'
 
-    def __str__(self):
-        return self.message
-
-class Missing_Token_Error(Exception):
+class Missing_Token_Error(CraedlException):
     def __init__(self):
         self.message = 'You have not configured an authentication token.\n'
         self.message += '  Use `python -m craedl` to configure your authentication token.'
 
-    def __str__(self):
-        return self.message
-
-class Not_Found_Error(Exception):
+class Not_Found_Error(CraedlException):
     def __init__(self):
         self.message = 'The requested resource was not found.'
 
-    def __str__(self):
-        return self.message
-
-class Other_Error(Exception):
+class Other_Error(CraedlException):
     def __init__(self):
         self.message = 'New error encountered. Determine the response error code and create a new error class.'
 
-    def __str__(self):
-        return self.message
-
-class Parse_Error(Exception):
+class Parse_Error(CraedlException):
     def __init__(self, details=None):
         self.message = 'Your request included invalid parameters.'
         self.details = details
@@ -59,13 +52,18 @@ class Parse_Error(Exception):
     def __str__(self):
         return self.message + ' ' + self.details
 
-class Server_Error(Exception):
+class File_Error(CraedlException):
+    def __init__(self, details=None):
+        self.message = 'Cannot upload an empty file.'
+        self.details = details
+
+    def __str__(self):
+        return self.message + ' file: ' + self.details
+
+class Server_Error(CraedlException):
     def __init__(self, details=None):
         self.message = 'The server at https://api.craedl.org has encountered an error.'
 
-    def __str__(self):
-        return self.message
-
-class Unauthorized_Error(Exception):
+class Unauthorized_Error(CraedlException):
     def __init__(self):
         self.message = 'You are not authorized to access the requested resource.'


### PR DESCRIPTION
In the case that and empty file is uploaded, craedl will crash (an error is given through the web interface as well). The edge case is now caught and an appropriate error is now produced.

also refactored errors (but maybe this is a bit over reaching 😄)