### PR TITLE
Fix upload function

### DIFF
--- a/craedl/core.py
+++ b/craedl/core.py
@@ -227,7 +227,8 @@ class Directory(Auth):
         }
         response_data = self.POST('file/', data)
         response_data2 = self.PUT_DATA(
-            'data/' + str(response_data['id']) + '/',
+            ('data/' + str(response_data['id']) + '/?vid=' +
+                    str(response_data['vid'])),
             open(file_path, 'rb')
         )
         return Directory(self.id)


### PR DESCRIPTION
Added `vid` query parameter to allow for file uploads. See https://github.com/craedl/craedl-sdk-python/issues/2